### PR TITLE
Support resource identifiers in batching 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: java
+
+jdk:
+- oraclejdk8
+
+cache:
+  directories:
+  - $HOME/.m2
+  - .cache
+
+script:
+- mvn -D environment=test verify

--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# ffwd-http-client &#187;
+[![Build Status](https://travis-ci.org/spotify/ffwd.svg?branch=master)](https://travis-ci.org/spotify/ffwd)
+[![License](https://img.shields.io/github/license/spotify/ffwd.svg)](LICENSE)
+
+
+This is a java http client for interacting with [ffwd](https://github.com/spotify/ffwd).
+
+
+# Installation
+
+Add a dependency in Maven. 
+```xml
+<dependency>
+  <groupId>com.spotify.ffwd</groupId>
+  <artifactId>ffwd-http-client</artifactId>
+  <version>${ffwd-http-client.version}</version>
+</dependency>
+```

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,12 @@
     </dependency>
 
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>18.0</version>
+    </dependency>
+
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <version>${jackson.version}</version>

--- a/src/main/java/com/spotify/ffwd/http/Batch.java
+++ b/src/main/java/com/spotify/ffwd/http/Batch.java
@@ -20,45 +20,59 @@
 
 package com.spotify.ffwd.http;
 
+import com.google.common.collect.ImmutableMap;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+
 import lombok.Data;
 
 @Data
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Batch {
     private final Map<String, String> commonTags;
+    private final Map<String, String> commonResource;
     private final List<Point> points;
 
+    /**
+     * JSON creator.
+     */
     @JsonCreator
-    public Batch(
-        @JsonProperty("commonTags") final Map<String, String> commonTags,
+    public static Batch create(
+        @JsonProperty("commonTags") final Optional<Map<String, String>> commonTags,
+        @JsonProperty("commonResource") final Optional<Map<String, String>> commonResource,
         @JsonProperty("points") final List<Point> points
     ) {
-        this.commonTags = commonTags;
-        this.points = points;
+        return new Batch(commonTags.orElseGet(ImmutableMap::of),
+                         commonResource.orElseGet(ImmutableMap::of), points);
     }
 
     @Data
     public static class Point {
         private final String key;
         private final Map<String, String> tags;
+        private final Map<String, String> resource;
         private final double value;
         private final long timestamp;
 
-        public Point(
+        /**
+         * JSON creator.
+         */
+        @JsonCreator
+        public static Point create(
             @JsonProperty("key") final String key,
-            @JsonProperty("tags") final Map<String, String> tags,
+            @JsonProperty("tags") final Optional<Map<String, String>> tags,
+            @JsonProperty("resource") final Optional<Map<String, String>> resource,
             @JsonProperty("value") final double value,
             @JsonProperty("timestamp") final long timestamp
         ) {
-            this.key = key;
-            this.tags = tags;
-            this.value = value;
-            this.timestamp = timestamp;
+            return new Point(key, tags.orElseGet(ImmutableMap::of),
+                             resource.orElseGet(ImmutableMap::of), value, timestamp);
         }
     }
 }

--- a/src/test/java/com/spotify/ffwd/http/RawHttpClientTest.java
+++ b/src/test/java/com/spotify/ffwd/http/RawHttpClientTest.java
@@ -20,9 +20,6 @@
 
 package com.spotify.ffwd.http;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.junit.After;
@@ -82,8 +79,9 @@ public class RawHttpClientTest {
     @Test
     public void testSendBatchSuccess() {
         final String batchRequest =
-            "{\"commonTags\":{\"what\":\"error-rate\"},\"points\":[{\"key\":\"test_key\"," +
-                "\"tags\":{\"what\":\"error-rate\"},\"value\":1234.0,\"timestamp\":11111}]}";
+            "{\"commonTags\":{\"what\":\"error-rate\"},\"commonResource\":{},\"points\":"
+            + "[{\"key\":\"test_key\",\"tags\":{\"what\":\"error-rate\"},\"resource\":"
+            + "{},\"value\":1234.0,\"timestamp\":11111}]}";
 
         mockServerClient
             .when(request()
@@ -93,12 +91,7 @@ public class RawHttpClientTest {
                 .withBody(batchRequest))
             .respond(response().withStatusCode(200));
 
-        final Batch.Point point =
-            new Batch.Point("test_key", ImmutableMap.of("what", "error-rate"), 1234L, 11111L);
-        final Batch batch =
-            new Batch(ImmutableMap.of("what", "error-rate"), ImmutableList.of(point));
-
-        rawHttpClient.sendBatch(batch).toCompletable().await();
+        rawHttpClient.sendBatch(TestUtils.BATCH).toCompletable().await();
     }
 
     @Test
@@ -106,8 +99,9 @@ public class RawHttpClientTest {
         expected.expectMessage("500: Internal Server Error");
 
         final String batchRequest =
-            "{\"commonTags\":{\"what\":\"error-rate\"},\"points\":[{\"key\":\"test_key\"," +
-                "\"tags\":{\"what\":\"error-rate\"},\"value\":1234.0,\"timestamp\":11111}]}";
+            "{\"commonTags\":{\"what\":\"error-rate\"},\"commonResource\":{},\"points\":"
+            + "[{\"key\":\"test_key\",\"tags\":{\"what\":\"error-rate\"},\"resource\":"
+            + "{},\"value\":1234.0,\"timestamp\":11111}]}";
 
         mockServerClient
             .when(request()
@@ -117,11 +111,6 @@ public class RawHttpClientTest {
                 .withBody(batchRequest))
             .respond(response().withStatusCode(500));
 
-        final Batch.Point point =
-            new Batch.Point("test_key", ImmutableMap.of("what", "error-rate"), 1234L, 11111L);
-        final Batch batch =
-            new Batch(ImmutableMap.of("what", "error-rate"), ImmutableList.of(point));
-
-        rawHttpClient.sendBatch(batch).toCompletable().await();
+        rawHttpClient.sendBatch(TestUtils.BATCH).toCompletable().await();
     }
 }

--- a/src/test/java/com/spotify/ffwd/http/TestUtils.java
+++ b/src/test/java/com/spotify/ffwd/http/TestUtils.java
@@ -1,0 +1,41 @@
+/*-
+ * -\-\-
+ * FastForward HTTP Client
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.ffwd.http;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Optional;
+
+class TestUtils {
+
+  static final Batch.Point POINT =
+      Batch.Point.create("test_key",
+                         Optional.of(ImmutableMap.of("what", "error-rate")),
+                         Optional.empty(),
+                         1234L,
+                         11111L);
+
+  static final Batch BATCH =
+      Batch.create(Optional.of(
+          ImmutableMap.of("what", "error-rate")), Optional.empty(), ImmutableList.of(POINT));
+
+}


### PR DESCRIPTION
This allows the client to send resource identifiers when sending a batch of metrics.

There are also two separate commits for adding a readme and travis for CI.

@sjoeboo 