### PR TITLE
Add distribution support to ffwd-http-client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,6 +134,12 @@
     </dependency>
 
     <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>3.11.1</version>
+    </dependency>
+    <dependency>
+
       <groupId>io.reactivex</groupId>
       <artifactId>rxjava</artifactId>
       <version>1.3.3</version>

--- a/src/main/java/com/spotify/ffwd/http/HttpClient.java
+++ b/src/main/java/com/spotify/ffwd/http/HttpClient.java
@@ -53,6 +53,16 @@ public class HttpClient {
         }).retryWhen(new RetryWithDelay(retries, baseDelayMillis, maxDelayMillis));
     }
 
+    public Observable<Void> sendBatch(final com.spotify.ffwd.http.model.v2.Batch batch) {
+        return buildCommand().submit(new ServerOperation<Void>() {
+            @Override
+            public Observable<Void> call(final Server server) {
+                return HttpClient.this.clientFactory.newClient(server).sendBatch(batch);
+            }
+        }).retryWhen(new RetryWithDelay(retries, baseDelayMillis, maxDelayMillis));
+    }
+
+
     public void shutdown() {
         RuntimeException e = null;
 

--- a/src/main/java/com/spotify/ffwd/http/HttpClient.java
+++ b/src/main/java/com/spotify/ffwd/http/HttpClient.java
@@ -30,6 +30,7 @@ import com.netflix.loadbalancer.RetryRule;
 import com.netflix.loadbalancer.Server;
 import com.netflix.loadbalancer.reactive.LoadBalancerCommand;
 import com.netflix.loadbalancer.reactive.ServerOperation;
+import com.spotify.ffwd.http.model.v1.Batch;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.OkHttpClient;

--- a/src/main/java/com/spotify/ffwd/http/RawHttpClient.java
+++ b/src/main/java/com/spotify/ffwd/http/RawHttpClient.java
@@ -22,6 +22,7 @@ package com.spotify.ffwd.http;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.spotify.ffwd.http.model.v1.Batch;
 import java.io.IOException;
 import lombok.Data;
 import okhttp3.Call;

--- a/src/main/java/com/spotify/ffwd/http/RawHttpClient.java
+++ b/src/main/java/com/spotify/ffwd/http/RawHttpClient.java
@@ -37,6 +37,7 @@ import rx.Subscriber;
 @Data
 public class RawHttpClient {
     public static final String V1_BATCH_ENDPOINT = "v1/batch";
+    public static final String V2_BATCH_ENDPOINT = "v2/batch";
     public static final String PING_ENDPOINT = "ping";
 
     private final ObjectMapper mapper;
@@ -44,6 +45,14 @@ public class RawHttpClient {
     private final String baseUrl;
 
     public Observable<Void> sendBatch(final Batch batch) {
+        return sendBatch(batch, V1_BATCH_ENDPOINT);
+    }
+
+    public Observable<Void> sendBatch(final com.spotify.ffwd.http.model.v2.Batch batch) {
+        return sendBatch(batch, V2_BATCH_ENDPOINT);
+    }
+
+    private Observable<Void> sendBatch(final Object batch, final String url) {
         final byte[] body;
 
         try {
@@ -54,11 +63,12 @@ public class RawHttpClient {
 
         final Request.Builder request = new Request.Builder();
 
-        request.url(baseUrl + "/" + V1_BATCH_ENDPOINT);
+        request.url(baseUrl + "/" + url);
         request.post(RequestBody.create(MediaType.parse("application/json"), body));
 
         return execute(request);
     }
+
 
     public Observable<Void> ping() {
         final Request.Builder request = new Request.Builder();

--- a/src/main/java/com/spotify/ffwd/http/RetryWithDelay.java
+++ b/src/main/java/com/spotify/ffwd/http/RetryWithDelay.java
@@ -51,7 +51,6 @@ public class RetryWithDelay implements Func1<Observable<? extends Throwable>, Ob
                     retryDelayMillis = Math.min(retryDelayMillis * 2, maxDelayMillis);
                     return Observable.timer(retryMillis + jitter, TimeUnit.MILLISECONDS);
                 }
-
                 // Max retries hit. Just pass the error along.
                 return Observable.error(throwable);
             }

--- a/src/main/java/com/spotify/ffwd/http/model/v1/Batch.java
+++ b/src/main/java/com/spotify/ffwd/http/model/v1/Batch.java
@@ -18,7 +18,7 @@
  * -/-/-
  */
 
-package com.spotify.ffwd.http;
+package com.spotify.ffwd.http.model.v1;
 
 import com.google.common.collect.ImmutableMap;
 

--- a/src/main/java/com/spotify/ffwd/http/model/v2/Batch.java
+++ b/src/main/java/com/spotify/ffwd/http/model/v2/Batch.java
@@ -1,0 +1,82 @@
+/*-
+ * -\-\-
+ * FastForward API
+ * --
+ * Copyright (C) 2016 - 2020 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.ffwd.http.model.v2;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+/**
+ * This class represents a batch of points.
+ * This implementation of the batch uses {@link Value} as the point value.
+ */
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+@EqualsAndHashCode(of = {"commonTags", "commonResource"})
+public class Batch {
+    private final Map<String, String> commonTags;
+    private final Map<String, String> commonResource;
+    private final List<Point> points;
+
+    /**
+     * JSON creator.
+     */
+    @JsonCreator
+    public static Batch create(
+        @JsonProperty("commonTags")
+        final Optional<Map<String, String>> commonTags,
+        @JsonProperty("commonResource") final Optional<Map<String, String>> commonResource,
+        @JsonProperty("points") final List<Point> points
+    ) {
+        return new Batch(commonTags.orElseGet(ImmutableMap::of),
+            commonResource.orElseGet(ImmutableMap::of), points);
+    }
+
+    @Data
+    public static class Point {
+        private final String key;
+        private final Map<String, String> tags;
+        private final Map<String, String> resource;
+        private final Value value;
+        private final long timestamp;
+
+        /**
+         * JSON creator.
+         */
+        @JsonCreator
+        public static  Point create(
+            @JsonProperty("key") final String key,
+            @JsonProperty("tags") final Optional<Map<String, String>> tags,
+            @JsonProperty("resource") final Optional<Map<String, String>> resource,
+            @JsonProperty("value") final Value value,
+            @JsonProperty("timestamp") final long timestamp
+        ) {
+            return new Point(key, tags.orElseGet(ImmutableMap::of),
+                resource.orElseGet(ImmutableMap::of), value, timestamp);
+        }
+    }
+}

--- a/src/main/java/com/spotify/ffwd/http/model/v2/Value.java
+++ b/src/main/java/com/spotify/ffwd/http/model/v2/Value.java
@@ -1,0 +1,86 @@
+/*-
+ * -\-\-
+ * FastForward API
+ * --
+ * Copyright (C) 2016 - 2020 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.ffwd.http.model.v2;
+
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.protobuf.ByteString;
+import lombok.Data;
+
+/**
+ * Distribution histogram point value. Currently we
+ * support {@link Value.DoubleValue} and {@link Value.DistributionValue}
+ */
+@JsonSerialize(using = ValueSerializer.class)
+@JsonDeserialize(using = ValueDeserializer.class)
+public  abstract class Value {
+    @JsonProperty("value")
+    public abstract Object getValue();
+
+    abstract boolean isValid();
+
+    @Data
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class DoubleValue extends Value {
+        private final Double value;
+
+        public static Value.DoubleValue create(
+                final double value) {
+            return new Value.DoubleValue(value);
+        }
+
+        @Override
+        public boolean isValid() {
+            return (getValue() > 0); //TODO NaN ??
+        }
+
+        @Override
+        public Double getValue() {
+            return value;
+        }
+    }
+
+    @Data
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class DistributionValue  extends Value {
+        private final ByteString value;
+
+
+        @Override
+        public ByteString getValue() {
+            return value;
+        }
+
+        @Override
+        public boolean isValid() {
+            return (getValue() != null &&
+                    !getValue().isEmpty()); //TODO NaN ??
+        }
+
+        public static Value.DistributionValue create(
+                final ByteString value) {
+            return new Value.DistributionValue(value);
+        }
+    }
+}

--- a/src/main/java/com/spotify/ffwd/http/model/v2/Value.java
+++ b/src/main/java/com/spotify/ffwd/http/model/v2/Value.java
@@ -38,8 +38,6 @@ public  abstract class Value {
     @JsonProperty("value")
     public abstract Object getValue();
 
-    abstract boolean isValid();
-
     @Data
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class DoubleValue extends Value {
@@ -49,16 +47,6 @@ public  abstract class Value {
                 final double value) {
             return new Value.DoubleValue(value);
         }
-
-        @Override
-        public boolean isValid() {
-            return (getValue() > 0); //TODO NaN ??
-        }
-
-        @Override
-        public Double getValue() {
-            return value;
-        }
     }
 
     @Data
@@ -66,17 +54,11 @@ public  abstract class Value {
     public static class DistributionValue  extends Value {
         private final ByteString value;
 
-
         @Override
         public ByteString getValue() {
             return value;
         }
 
-        @Override
-        public boolean isValid() {
-            return (getValue() != null &&
-                    !getValue().isEmpty()); //TODO NaN ??
-        }
 
         public static Value.DistributionValue create(
                 final ByteString value) {

--- a/src/main/java/com/spotify/ffwd/http/model/v2/ValueDeserializer.java
+++ b/src/main/java/com/spotify/ffwd/http/model/v2/ValueDeserializer.java
@@ -1,0 +1,67 @@
+/*-
+ * -\-\-
+ * FastForward API
+ * --
+ * Copyright (C) 2016 - 2020 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.ffwd.http.model.v2;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.google.protobuf.ByteString;
+import java.io.IOException;
+
+/**
+ * Distribution histogram point value type deserializer
+ * This deserialize supports  {@link Value.DistributionValue}
+ * and {@link Value.DoubleValue} types.
+ */
+public class ValueDeserializer extends StdDeserializer<Value> {
+
+    private static final long serialVersionUID = 6224613339173782914L;
+
+    public ValueDeserializer() {
+        this(Value.class);
+    }
+
+
+    public ValueDeserializer(final Class<Value> classz) {
+        super(classz);
+    }
+
+    @Override
+    public Value deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
+            throws IOException, JsonProcessingException {
+
+        JsonNode node = jsonParser.getCodec().readTree(jsonParser);
+
+        if (node.get("distributionValue") != null) {
+            byte[] bytes = node.get("distributionValue").binaryValue();
+            ByteString byteString = ByteString.copyFrom(bytes);
+            return Value.DistributionValue.create(byteString);
+        }
+
+        if (node.get("doubleValue") != null) {
+            double val = node.get("doubleValue").asDouble();
+            return Value.DoubleValue.create(val);
+        }
+
+        throw new RuntimeException("Unrecognized value type");
+    }
+}

--- a/src/main/java/com/spotify/ffwd/http/model/v2/ValueSerializer.java
+++ b/src/main/java/com/spotify/ffwd/http/model/v2/ValueSerializer.java
@@ -1,0 +1,69 @@
+/*-
+ * -\-\-
+ * FastForward API
+ * --
+ * Copyright (C) 2016 - 2020 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.ffwd.http.model.v2;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import java.io.IOException;
+
+/**
+ * Distribution histogram point value type serializer.
+ * This serializer supports {@link Value.DistributionValue}
+ * and {@link Value.DoubleValue} types.
+ */
+public class ValueSerializer extends StdSerializer<Value> {
+
+    private static final long serialVersionUID = 6300597228325654588L;
+
+    public ValueSerializer() {
+        this(Value.class);
+    }
+
+
+
+    public ValueSerializer(Class<Value> t) {
+        super(t);
+    }
+
+
+    @Override
+    public void serialize(Value value, JsonGenerator jsonGenerator,
+                          SerializerProvider serializerProvider) throws IOException {
+
+        if (value instanceof  Value.DistributionValue) {
+            Value.DistributionValue distributionValue = (Value.DistributionValue) value;
+            jsonGenerator.writeStartObject();
+            jsonGenerator.writeObjectField("distributionValue",
+                    distributionValue.getValue().toByteArray());
+            jsonGenerator.writeEndObject();
+        } else if (value instanceof  Value.DoubleValue) {
+            Value.DoubleValue doubleValue = (Value.DoubleValue) value;
+            jsonGenerator.writeStartObject();
+            jsonGenerator.writeNumberField("doubleValue", doubleValue.getValue());
+            jsonGenerator.writeEndObject();
+        } else {
+            throw new RuntimeException("Failed to serialize. Value type is not supported " + value);
+        }
+
+    }
+}
+

--- a/src/test/java/com/spotify/ffwd/http/HttpClientTest.java
+++ b/src/test/java/com/spotify/ffwd/http/HttpClientTest.java
@@ -52,10 +52,11 @@ public class HttpClientTest {
     private final List<HttpDiscovery.HostAndPort> servers = new ArrayList<>();
 
     private final static int SUCCESS = 200;
+    private final static int ERROR_CODE = 500;
 
     @Before
     public void setUp() throws Exception {
-        mockServerClient.when(pingRequest).respond(response().withStatusCode(200));
+        mockServerClient.when(pingRequest).respond(response().withStatusCode(SUCCESS));
 
         servers.add(new HttpDiscovery.HostAndPort("localhost", mockServer.getPort()));
         servers.add(new HttpDiscovery.HostAndPort("localhost", mockServer.getPort()));
@@ -101,7 +102,7 @@ public class HttpClientTest {
     public void testSendBatchFail() {
         expected.expectMessage("500: Internal Server Error");
         final String batchRequest = TestUtils.createJsonString(TestUtils.BATCH);
-        final HttpRequest request = sendRequest( batchRequest, RawHttpClient.V1_BATCH_ENDPOINT, 500);
+        final HttpRequest request = sendRequest( batchRequest, RawHttpClient.V1_BATCH_ENDPOINT, ERROR_CODE);
         try {
             httpClient.sendBatch(TestUtils.BATCH).toCompletable().await();
         } finally {

--- a/src/test/java/com/spotify/ffwd/http/HttpClientTest.java
+++ b/src/test/java/com/spotify/ffwd/http/HttpClientTest.java
@@ -51,6 +51,8 @@ public class HttpClientTest {
 
     private final List<HttpDiscovery.HostAndPort> servers = new ArrayList<>();
 
+    private final static int SUCCESS = 200;
+
     @Before
     public void setUp() throws Exception {
         mockServerClient.when(pingRequest).respond(response().withStatusCode(200));
@@ -70,41 +72,36 @@ public class HttpClientTest {
 
     @Test
     public void testSendBatchSuccess() {
-        final String batchRequest =
-            "{\"commonTags\":{\"what\":\"error-rate\"},\"commonResource\":{},\"points\":"
-            + "[{\"key\":\"test_key\",\"tags\":{\"what\":\"error-rate\"},\"resource\":"
-            + "{},\"value\":1234.0,\"timestamp\":11111}]}";
-
-        final HttpRequest request = request()
-            .withMethod("POST")
-            .withPath("/v1/batch")
-            .withHeader("content-type", "application/json")
-            .withBody(batchRequest);
-
-        mockServerClient.when(request).respond(response().withStatusCode(200));
-
+        final String batchRequest = TestUtils.createJsonString(TestUtils.BATCH);
+        final HttpRequest request = sendRequest(batchRequest, RawHttpClient.V1_BATCH_ENDPOINT, SUCCESS);
         httpClient.sendBatch(TestUtils.BATCH).toCompletable().await();
-
         mockServerClient.verify(request, VerificationTimes.atLeast(1));
+    }
+
+    @Test
+    public void testSendBatchSuccessV2() {
+        final String batchRequest = TestUtils.createJsonString(TestUtils.BATCH_V2);
+        final HttpRequest request = sendRequest(batchRequest, RawHttpClient.V2_BATCH_ENDPOINT, SUCCESS);
+        httpClient.sendBatch(TestUtils.BATCH_V2).toCompletable().await();
+        mockServerClient.verify(request, VerificationTimes.atLeast(1));
+    }
+
+    private HttpRequest sendRequest(final String json, final String url, final int statusCode){
+        final HttpRequest request = request()
+                .withMethod("POST")
+                .withPath( "/" + url)
+                .withHeader("content-type", "application/json")
+                .withBody(json);
+
+        mockServerClient.when(request).respond(response().withStatusCode(statusCode));
+        return request;
     }
 
     @Test
     public void testSendBatchFail() {
         expected.expectMessage("500: Internal Server Error");
-
-        final String batchRequest =
-            "{\"commonTags\":{\"what\":\"error-rate\"},\"commonResource\":{},\"points\":"
-            + "[{\"key\":\"test_key\",\"tags\":{\"what\":\"error-rate\"},\"resource\":"
-            + "{},\"value\":1234.0,\"timestamp\":11111}]}";
-
-        final HttpRequest request = request()
-            .withMethod("POST")
-            .withPath("/v1/batch")
-            .withHeader("content-type", "application/json")
-            .withBody(batchRequest);
-
-        mockServerClient.when(request).respond(response().withStatusCode(500));
-
+        final String batchRequest = TestUtils.createJsonString(TestUtils.BATCH);
+        final HttpRequest request = sendRequest( batchRequest, RawHttpClient.V1_BATCH_ENDPOINT, 500);
         try {
             httpClient.sendBatch(TestUtils.BATCH).toCompletable().await();
         } finally {

--- a/src/test/java/com/spotify/ffwd/http/RawHttpClientTest.java
+++ b/src/test/java/com/spotify/ffwd/http/RawHttpClientTest.java
@@ -31,6 +31,8 @@ import org.mockserver.client.server.MockServerClient;
 import org.mockserver.junit.MockServerRule;
 
 import okhttp3.OkHttpClient;
+import org.mockserver.model.HttpRequest;
+
 
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
@@ -92,6 +94,20 @@ public class RawHttpClientTest {
             .respond(response().withStatusCode(200));
 
         rawHttpClient.sendBatch(TestUtils.BATCH).toCompletable().await();
+    }
+
+    @Test
+    public void testSendBatchSuccessV2() {
+        final String batchRequest = TestUtils.createJsonString(TestUtils.BATCH_V2);
+        mockServerClient
+                .when(request()
+                        .withMethod("POST")
+                        .withPath("/" + RawHttpClient.V2_BATCH_ENDPOINT)
+                        .withHeader("content-type", "application/json")
+                        .withBody(batchRequest))
+                .respond(response().withStatusCode(200));
+
+        rawHttpClient.sendBatch(TestUtils.BATCH_V2).toCompletable().await();
     }
 
     @Test

--- a/src/test/java/com/spotify/ffwd/http/RawHttpClientTest.java
+++ b/src/test/java/com/spotify/ffwd/http/RawHttpClientTest.java
@@ -38,6 +38,13 @@ import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
 
 public class RawHttpClientTest {
+    private static final  String  REQUEST_JSON =  "{\"commonTags\":{\"what\":\"error-rate\"}," +
+            "\"commonResource\":{},\"points\":"
+            + "[{\"key\":\"test_key\",\"tags\":{\"what\":\"error-rate\"},\"resource\":"
+            + "{},\"value\":1234.0,\"timestamp\":11111}]}";
+    private static final int SUCCESS = 200;
+    private static final int ERROR_CODE = 500;
+
     @Rule
     public MockServerRule mockServer = new MockServerRule(this);
 
@@ -74,59 +81,37 @@ public class RawHttpClientTest {
     public void testPing() {
         mockServerClient
             .when(request().withMethod("GET").withPath("/ping"))
-            .respond(response().withStatusCode(200));
+            .respond(response().withStatusCode(SUCCESS));
         rawHttpClient.ping().toCompletable().await();
     }
 
     @Test
     public void testSendBatchSuccess() {
-        final String batchRequest =
-            "{\"commonTags\":{\"what\":\"error-rate\"},\"commonResource\":{},\"points\":"
-            + "[{\"key\":\"test_key\",\"tags\":{\"what\":\"error-rate\"},\"resource\":"
-            + "{},\"value\":1234.0,\"timestamp\":11111}]}";
-
-        mockServerClient
-            .when(request()
-                .withMethod("POST")
-                .withPath("/v1/batch")
-                .withHeader("content-type", "application/json")
-                .withBody(batchRequest))
-            .respond(response().withStatusCode(200));
-
+        sendRequestToMockClient(REQUEST_JSON, RawHttpClient.V1_BATCH_ENDPOINT, SUCCESS);
         rawHttpClient.sendBatch(TestUtils.BATCH).toCompletable().await();
     }
 
     @Test
     public void testSendBatchSuccessV2() {
         final String batchRequest = TestUtils.createJsonString(TestUtils.BATCH_V2);
-        mockServerClient
-                .when(request()
-                        .withMethod("POST")
-                        .withPath("/" + RawHttpClient.V2_BATCH_ENDPOINT)
-                        .withHeader("content-type", "application/json")
-                        .withBody(batchRequest))
-                .respond(response().withStatusCode(200));
-
+        sendRequestToMockClient(batchRequest, RawHttpClient.V2_BATCH_ENDPOINT, SUCCESS);
         rawHttpClient.sendBatch(TestUtils.BATCH_V2).toCompletable().await();
     }
 
     @Test
     public void testSendBatchFail() {
         expected.expectMessage("500: Internal Server Error");
-
-        final String batchRequest =
-            "{\"commonTags\":{\"what\":\"error-rate\"},\"commonResource\":{},\"points\":"
-            + "[{\"key\":\"test_key\",\"tags\":{\"what\":\"error-rate\"},\"resource\":"
-            + "{},\"value\":1234.0,\"timestamp\":11111}]}";
-
-        mockServerClient
-            .when(request()
-                .withMethod("POST")
-                .withPath("/v1/batch")
-                .withHeader("content-type", "application/json")
-                .withBody(batchRequest))
-            .respond(response().withStatusCode(500));
-
+        sendRequestToMockClient(REQUEST_JSON, RawHttpClient.V1_BATCH_ENDPOINT, ERROR_CODE);
         rawHttpClient.sendBatch(TestUtils.BATCH).toCompletable().await();
+    }
+
+    private void sendRequestToMockClient(final String requestJson, final String url, final int statusCode) {
+        mockServerClient
+                .when(request()
+                        .withMethod("POST")
+                        .withPath("/" + url)
+                        .withHeader("content-type", "application/json")
+                        .withBody(requestJson))
+                .respond(response().withStatusCode(statusCode));
     }
 }

--- a/src/test/java/com/spotify/ffwd/http/TestUtils.java
+++ b/src/test/java/com/spotify/ffwd/http/TestUtils.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
+import com.spotify.ffwd.http.model.v1.Batch;
 import com.spotify.ffwd.http.model.v2.Value;
 import java.util.Optional;
 import com.google.protobuf.ByteString;

--- a/src/test/java/com/spotify/ffwd/http/TestUtils.java
+++ b/src/test/java/com/spotify/ffwd/http/TestUtils.java
@@ -20,10 +20,13 @@
 
 package com.spotify.ffwd.http;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
+import com.spotify.ffwd.http.model.v2.Value;
 import java.util.Optional;
+import com.google.protobuf.ByteString;
 
 class TestUtils {
 
@@ -33,9 +36,35 @@ class TestUtils {
                          Optional.empty(),
                          1234L,
                          11111L);
+  static final com.spotify.ffwd.http.model.v2.Batch.Point DISTRIBUTION_POINT_1 =
+          com.spotify.ffwd.http.model.v2.Batch.Point.create("test_key",
+                  Optional.of(ImmutableMap.of("what", "error-rate")),
+                  Optional.empty(),
+                  Value.DoubleValue.create(1234D),
+                  11111L);
+
+  static final com.spotify.ffwd.http.model.v2.Batch.Point DISTRIBUTION_POINT_2 =
+          com.spotify.ffwd.http.model.v2.Batch.Point.create("test_key",
+                  Optional.of(ImmutableMap.of("what", "error-rate")),
+                  Optional.empty(),
+                  Value.DistributionValue.create(ByteString.copyFromUtf8("ABCDEFG_1234")),
+                  11123L);
 
   static final Batch BATCH =
       Batch.create(Optional.of(
           ImmutableMap.of("what", "error-rate")), Optional.empty(), ImmutableList.of(POINT));
 
+  static final com.spotify.ffwd.http.model.v2.Batch BATCH_V2 =
+          com.spotify.ffwd.http.model.v2.Batch.create(Optional.of(
+                  ImmutableMap.of("what", "error-rate")),
+                  Optional.empty(), ImmutableList.of(DISTRIBUTION_POINT_1, DISTRIBUTION_POINT_2));
+
+  static String createJsonString(Object object) {
+    final ObjectMapper mapper = HttpClient.Builder.setupApplicationJson();
+    try {
+      return mapper.writeValueAsString(object);
+    }catch(Exception e){
+      throw new RuntimeException(e);
+    }
+  }
 }


### PR DESCRIPTION
Heroic histogram data is currently computed locally.
It is practically impossible to aggregate percentile.
We are adding distribution to heroic to address that issue. Distribution will create data sketch that will be used upstream to compute percentile on the entire data distribution.

This PR will add distribution support to ffwd-http-client. By adding a new implementation of Batch and a new endpoint "v2/batch".  "v1/batch" endpoint is not affected by this change.


Related Task : https://github.com/spotify/semantic-metrics/issues/83


